### PR TITLE
Fixed issue where subscribing to a feed always returned an error

### DIFF
--- a/lib/superfeedr.js
+++ b/lib/superfeedr.js
@@ -182,7 +182,7 @@ Superfeedr.prototype.subscribe = function(url, clb) {
       return;
     }
 
-    var subscription = pubsub.getChild('subscribe', 'http://jabber.org/protocol/pubsub');
+    var subscription = pubsub.getChild('subscription', 'http://jabber.org/protocol/pubsub');
     if (!subscription) {
       clb(new Error("Superfeedr did not respond with a subscription"), null);
       return;


### PR DESCRIPTION
I am unable to subscribe to a feed...sort of.

``` coffeescript
Superfeedr = require 'superfeedr'
feedClient = new Superfeedr 'user', 'pass'

feedClient.subscribe 'http://blog.superfeedr.com/atom.xml', (err, feed) ->
```

This does in fact subscribe the account to a feed, but returns an error anyway. It appears to have been introduced in commit 49261e05c3d73e604a8832bf70f547677e628567 at [Line 185](https://github.com/superfeedr/superfeedr-node/blob/master/lib/superfeedr.js#L185) where it attempts to obtain the child by the name of "subscribe" instead of "subscription"

If I am missing something please let me know.
