### PR TITLE
Fix basic example.

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,4 +1,4 @@
-var Superfeedr = require('superfeedr').Superfeedr;
+var Superfeedr = require('superfeedr');
 
 client = new Superfeedr("login", "password");
 client.on('connected', function() {


### PR DESCRIPTION
It looks like the superfeedr module changed at some point to be used via require('superfeedr') rather than require('superfeedr').Superfeedr. This commit fixes that change in the basic example.
